### PR TITLE
Clean Pipenv virtual env names in prompt

### DIFF
--- a/sections/venv.zsh
+++ b/sections/venv.zsh
@@ -35,7 +35,7 @@ spaceship_venv() {
   then
     venv="$VIRTUAL_ENV:h:t"
   else
-    venv="$VIRTUAL_ENV:t"
+    venv="${${(@s|-|)VIRTUAL_ENV:t}[1]}"
   fi
 
   if [[ $SPACESHIP_VENV_PYTHON_VERSION_SHOW == true ]]; then


### PR DESCRIPTION
#### Description

Pipenv creates unique virtual environments for projects and names them 
from hash value of directory names. But this clutters prompt with random 
characters. Naming scheme followed by Pipenv (which uses pew) is 
`DIRECTORY-hash`. With this change we're removing the second part from 
the prompt and display on the directory name, Behavior similar for generic 
names.

 #### Breaks

This will break for directories with dashed names. They'll be truncated
to the first part.

 #### Existing behvaior

```zsh
studentlist on  remove_pdf_generation [$!?] via studentlist-oHFRN5Ln:3.7.0
➜
```


 #### New behavior

```zsh
studentlist on  remove_pdf_generation [$!?] via studentlist:3.7.0
➜
```
